### PR TITLE
Fixing numerical instability problems 

### DIFF
--- a/glow/net.py
+++ b/glow/net.py
@@ -46,7 +46,7 @@ class NN(nn.Module):
             
     def forward(self, x):
         x = self.conv1(x)
-        x, _, _ = self.actnorm1(x, logdet=0, reverse=False) 
+        x, _, _ = self.actnorm1(x, logdet=0, reverse=False) # these actnorms never run in reverse mode, even if the network is in reverse mode
         x = F.relu(x)
         x = self.conv2(x)
         x, _, _ = self.actnorm2(x, logdet=0, reverse=False) 

--- a/solvers/cs.py
+++ b/solvers/cs.py
@@ -160,7 +160,6 @@ def GlowCS(args):
             if args.optim == "adam":
                 optimizer = torch.optim.Adam([z_sampled], lr=args.lr,)
             elif args.optim == "lbfgs":
-                # when using mean of pixelwise error rather than sum, the norm of gradients becomes small enough that LBFGS will ignore them by default - decreasing tolerance_grad prevents this
                 optimizer = torch.optim.LBFGS([z_sampled], lr=args.lr, tolerance_grad=0)
             else:
                 raise "optimizer not defined"
@@ -180,8 +179,6 @@ def GlowCS(args):
                     y_true      = torch.matmul(x_test_flat, A) + noise
                     y_gen       = torch.matmul(x_gen_flat, A) 
                     global residual_t
-                    # original error is computed as a sum over all measurement dims
-                    # using the mean instead prevents crashes, but it seems the only real change is that it scales the norm of the gradients by a constant
                     residual_t = ((y_gen - y_true)**2).mean()
                     z_reg_loss_t= gamma*z_sampled.norm(dim=1).mean()
                     loss_t      = residual_t + z_reg_loss_t


### PR DESCRIPTION
I made a few changes to allow myself to use `solve_cs.py` without getting the error 

`AssertionError: nan in coupling reverse: s=0.6357, x=3.4732, xa=3.8660, ya=nan, t=-5.469`

I am adding some extra notes about the changes below